### PR TITLE
fix(proforma): correct discount handling and status types

### DIFF
--- a/components/forms/proforma-invoice-form.tsx
+++ b/components/forms/proforma-invoice-form.tsx
@@ -59,11 +59,12 @@ import {
   editItemPriceOrQuantityToProforma,
 } from "@/lib/actions/proforma-actions";
 import { searchDiscount } from "@/lib/actions/discount-actions";
-import { Proforma } from "@/types/proforma/type";
+import type { Proforma, ProformaStatus } from "@/types/proforma/type";
 import { Customer } from "@/types/customer/type";
 import { FormResponse } from "@/types/types";
 import { Discount } from "@/types/discount/type";
 import { Gender } from "@/types/enums";
+import { firstPositive, resolveDiscount } from "@/lib/actions/total";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -100,14 +101,28 @@ interface BusinessInfo {
   tinNumber?: string | null;
 }
 
+/**
+ * The customer shape the preview needs.
+ *
+ * This is deliberately NOT `Pick<Customer, ...>`. It gets populated from two
+ * different sources — a `Customer` search result (non-null fields) and a
+ * `Proforma` payload (nullable fields) — so it has to accept the looser of the
+ * two. A real `Customer` still assigns into this without any change at the
+ * call site.
+ */
+interface PreviewCustomer {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+  phoneNumber: string | null;
+}
+
 interface ProformaState {
   id: string | null;
   proformaNumber: string | null;
-  proformaStatus: string | null;
-  customer: Pick<
-    Customer,
-    "id" | "firstName" | "lastName" | "email" | "phoneNumber"
-  > | null;
+  proformaStatus: ProformaStatus | null;
+  customer: PreviewCustomer | null;
   items: LineItem[];
   discount: number;
   discountId: string | null;
@@ -119,7 +134,6 @@ interface ProformaState {
   netAmount: number;
   taxAmount: number;
   showTaxBreakdown: boolean;
-  // ─── NEW: preview loading flag ───────────────────────────────────────────
   isPreviewLoading: boolean;
 }
 
@@ -1234,7 +1248,7 @@ function EditItemPanel({
     }).format(n);
 
   const handleSave = async () => {
-    if (!hasChanges) return;
+    if (!hasChanges || saving) return;
     setSaving(true);
     await onSave(item.itemId, qty, unitPrice);
     setSaving(false);
@@ -1364,6 +1378,7 @@ function DetailsStep({
   initialNote,
   initialExpiresAt,
   initialDiscount,
+  initialDiscountId,
   showTaxBreakdown,
   onTaxBreakdownChange,
   onSave,
@@ -1375,6 +1390,13 @@ function DetailsStep({
   initialNote: string;
   initialExpiresAt: string;
   initialDiscount: number;
+  /**
+   * When present, the saved discount came from the discount list — NOT a manual
+   * amount. Without this the step used to default every existing discount to
+   * "manual", so re-saving an API discount silently converted it to a manual
+   * one (and sent discountId: null).
+   */
+  initialDiscountId: string | null;
   showTaxBreakdown: boolean;
   onTaxBreakdownChange: (v: boolean) => void;
   onSave: (opts: {
@@ -1385,19 +1407,30 @@ function DetailsStep({
   }) => Promise<void>;
   onBack: () => void;
 }) {
+  const hasExistingDiscount = initialDiscount > 0 || !!initialDiscountId;
+
   const [notes, setNote] = useState(initialNote);
   const [expiresAt, setExpiresAt] = useState(initialExpiresAt);
   const [applyDiscount, setApplyDiscount] = useState<boolean | null>(
-    initialDiscount > 0 ? true : null,
+    hasExistingDiscount ? true : null,
   );
   const [discountSource, setDiscountSource] = useState<"api" | "manual">(
-    initialDiscount > 0 ? "manual" : "api",
+    initialDiscountId ? "api" : "manual",
   );
   const [selectedDiscount, setSelectedDiscount] = useState<Discount | null>(
     null,
   );
+  /**
+   * The API discount already attached to this proforma. We only have its id and
+   * resolved amount (the payload doesn't return the discount's name or rule), so
+   * it's tracked separately from `selectedDiscount` and treated as valid until
+   * the user replaces or clears it.
+   */
+  const [keptDiscountId, setKeptDiscountId] = useState<string | null>(
+    initialDiscountId,
+  );
   const [manualAmount, setManualAmount] = useState(
-    initialDiscount > 0 ? String(initialDiscount) : "",
+    !initialDiscountId && initialDiscount > 0 ? String(initialDiscount) : "",
   );
   const [saved, setSaved] = useState(false);
 
@@ -1409,11 +1442,16 @@ function DetailsStep({
     }).format(n);
 
   const effectiveDiscountAmount = (() => {
-    if (!applyDiscount || (!selectedDiscount && !manualAmount)) return 0;
-    if (discountSource === "api" && selectedDiscount) {
-      return selectedDiscount.discountType === "PERCENTAGE"
-        ? Math.round((grossTotal * selectedDiscount.discountValue) / 100)
-        : selectedDiscount.discountValue;
+    if (!applyDiscount) return 0;
+    if (discountSource === "api") {
+      if (selectedDiscount) {
+        return selectedDiscount.discountType === "PERCENTAGE"
+          ? Math.round((grossTotal * selectedDiscount.discountValue) / 100)
+          : selectedDiscount.discountValue;
+      }
+      // Keeping the discount that's already on the proforma.
+      if (keptDiscountId) return initialDiscount;
+      return 0;
     }
     return parseFloat(manualAmount) || 0;
   })();
@@ -1421,18 +1459,22 @@ function DetailsStep({
   const netTotal = Math.max(0, grossTotal - effectiveDiscountAmount);
   const hasValidDiscount =
     discountSource === "api"
-      ? !!selectedDiscount
+      ? !!selectedDiscount || !!keptDiscountId
       : (parseFloat(manualAmount) || 0) > 0;
-  const canSave = !applyDiscount || (applyDiscount && hasValidDiscount);
+  const canSave = !applyDiscount || hasValidDiscount;
 
   const handleSave = async () => {
     await onSave({
       notes,
       expiresAt,
       discountId:
-        discountSource === "api" ? (selectedDiscount?.id ?? null) : null,
+        applyDiscount && discountSource === "api"
+          ? (selectedDiscount?.id ?? keptDiscountId ?? null)
+          : null,
       manualDiscountAmount:
-        discountSource === "manual" ? parseFloat(manualAmount) || 0 : 0,
+        applyDiscount && discountSource === "manual"
+          ? parseFloat(manualAmount) || 0
+          : 0,
     });
     setSaved(true);
   };
@@ -1538,22 +1580,24 @@ function DetailsStep({
               type="button"
               onClick={() => {
                 setApplyDiscount(opt.value);
+                if (!opt.value) {
+                  // Explicitly removing the discount — drop the kept API one too.
+                  setKeptDiscountId(null);
+                  setSelectedDiscount(null);
+                  setManualAmount("");
+                }
                 setSaved(false);
               }}
               className={`p-3.5 rounded-xl border-2 text-left transition-all ${
                 applyDiscount === opt.value
-                  ? opt.value
-                    ? "border-[#EB7F44] bg-gray-50"
-                    : "border-[#EB7F44] bg-gray-50"
+                  ? "border-[#EB7F44] bg-gray-50"
                   : "border-gray-200 hover:border-gray-300 bg-white"
               }`}
             >
               <p
                 className={`text-sm font-semibold ${
                   applyDiscount === opt.value
-                    ? opt.value
-                      ? "text-gray-700"
-                      : "text-gray-800"
+                    ? "text-gray-700"
                     : "text-gray-600"
                 }`}
               >
@@ -1576,6 +1620,8 @@ function DetailsStep({
                   setDiscountSource(src);
                   setSelectedDiscount(null);
                   setManualAmount("");
+                  // Switching to manual abandons the attached API discount.
+                  if (src === "manual") setKeptDiscountId(null);
                   setSaved(false);
                 }}
                 className={`flex-1 py-1.5 rounded-md text-sm font-medium transition-all ${
@@ -1596,9 +1642,39 @@ function DetailsStep({
               <DiscountSearch
                 onSelect={(d) => {
                   setSelectedDiscount(d);
+                  setKeptDiscountId(null); // replaced by the new selection
                   setSaved(false);
                 }}
               />
+
+              {/* An API discount is already attached and hasn't been replaced. */}
+              {!selectedDiscount && keptDiscountId && (
+                <div className="flex items-center justify-between p-3 bg-gray-50 border border-gray-200 rounded-lg">
+                  <div className="flex items-center gap-2">
+                    <PercentIcon className="w-4 h-4 text-gray-700" />
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900">
+                        Existing discount applied
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {fmt(initialDiscount)} off — search above to replace it
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setKeptDiscountId(null);
+                      setSaved(false);
+                    }}
+                    className="text-gray-400 hover:text-gray-600"
+                    title="Remove this discount"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+              )}
+
               {selectedDiscount && (
                 <div className="flex items-center justify-between p-3 bg-gray-50 border border-gray-200 rounded-lg">
                   <div className="flex items-center gap-2">
@@ -1666,7 +1742,7 @@ function DetailsStep({
 
       <Button
         type="button"
-        className="w-full bg-[#EB7F44]  text-white h-11 shadow-sm font-medium"
+        className="w-full bg-[#EB7F44] text-white h-11 shadow-sm font-medium"
         disabled={pending || !canSave}
         onClick={handleSave}
       >
@@ -1703,9 +1779,6 @@ function DetailsStep({
 }
 
 // ─── Live Preview ─────────────────────────────────────────────────────────────
-// NEW: accepts isLoading prop and renders a frosted overlay while any
-// server-side mutation is in flight, keeping the stale content visible
-// beneath it so the user can see exactly what is being updated.
 
 function ProformaPreview({
   state,
@@ -1721,19 +1794,17 @@ function ProformaPreview({
       style: "currency",
       currency: "TZS",
       minimumFractionDigits: 2,
-    }).format(n);
+    }).format(Number.isFinite(n) ? n : 0);
 
   const fmtDate = (d: string) => {
     if (!d) return "";
-    try {
-      return new Date(d).toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      });
-    } catch {
-      return d;
-    }
+    const parsed = new Date(d);
+    if (Number.isNaN(parsed.getTime())) return d;
+    return parsed.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
   };
 
   const grossAmount =
@@ -1751,20 +1822,24 @@ function ProformaPreview({
 
   const taxAmount = state.taxAmount;
 
-  const netAmount =
-    state.netAmount > 0
-      ? state.netAmount
-      : Math.max(0, grossAmount - (state.discount ?? 0));
+  // The preview always shows gross - discount. The server's netAmount is
+  // currently unreliable when a manual discount is present (it comes back equal
+  // to grossAmount), so trusting it here would show a total that doesn't add up.
+  const netAmount = Math.max(0, grossAmount - (state.discount ?? 0));
+
+  // Derived, not hardcoded — the 18% literal used to be baked into two places.
+  const vatRate =
+    taxExclusiveGrossAmount > 0 && taxAmount > 0
+      ? Math.round((taxAmount / taxExclusiveGrossAmount) * 100)
+      : null;
 
   return (
-    // position: relative is required so the absolute overlay is contained here
     <div className="relative bg-white rounded-2xl border border-gray-200 shadow-sm p-6 text-[12.5px] sticky top-4 transition-all duration-300">
       {/* ── Loading overlay ── */}
       {isLoading && (
         <div
           className="absolute inset-0 z-10 rounded-2xl flex flex-col items-center justify-center gap-2.5"
           style={{
-            // Semi-transparent white so the stale content shows through
             backgroundColor: "rgba(255, 255, 255, 0.72)",
             backdropFilter: "blur(2px)",
             WebkitBackdropFilter: "blur(2px)",
@@ -1848,7 +1923,9 @@ function ProformaPreview({
         </p>
         <div className="space-y-0.5">
           <p className="font-bold text-gray-900">
-            {state.customer.firstName} {state.customer.lastName}
+            {[state.customer.firstName, state.customer.lastName]
+              .filter(Boolean)
+              .join(" ") || "—"}
           </p>
           {state.customer.email && (
             <p className="text-gray-500">{state.customer.email}</p>
@@ -1891,7 +1968,7 @@ function ProformaPreview({
                 <tr key={it.itemId} className="border-b border-gray-50">
                   <td className="py-2 text-gray-800">
                     {it.productName}
-                    {it.variantName && (
+                    {it.variantName && it.variantName !== it.productName && (
                       <span className="text-gray-400"> — {it.variantName}</span>
                     )}
                   </td>
@@ -1927,9 +2004,11 @@ function ProformaPreview({
               <div className="flex justify-between text-emerald-600 font-medium">
                 <span className="flex items-center gap-1">
                   VAT
-                  <span className="text-[10px] text-gray-400 font-normal">
-                    (18%)
-                  </span>
+                  {vatRate !== null && (
+                    <span className="text-[10px] text-gray-400 font-normal">
+                      ({vatRate}%)
+                    </span>
+                  )}
                 </span>
                 <span>+ {fmt(taxAmount)}</span>
               </div>
@@ -1974,8 +2053,8 @@ function ProformaPreview({
         <div className="mb-4 flex items-center gap-2 px-3 py-2 bg-emerald-50 border border-emerald-100 rounded-lg">
           <PercentIcon className="w-3.5 h-3.5 text-emerald-600 shrink-0" />
           <p className="text-[11px] text-emerald-700">
-            Prices are <span className="font-semibold">VAT-inclusive</span> at
-            18%. Tax amount:{" "}
+            Prices are <span className="font-semibold">VAT-inclusive</span>
+            {vatRate !== null ? ` at ${vatRate}%` : ""}. Tax amount:{" "}
             <span className="font-semibold">{fmt(taxAmount)}</span>
           </p>
         </div>
@@ -2028,10 +2107,10 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
         taxAmount: 0,
         netAmount: 0,
         showTaxBreakdown: false,
-        // ─── NEW ───────────────────────────────────────────────────────────
         isPreviewLoading: false,
       };
     }
+
     return {
       id: item.id,
       proformaNumber: item.proformaNumber,
@@ -2047,29 +2126,33 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
         itemId: i.id,
         variantId: i.id,
         productName: i.productName,
-        variantName: i.productVariantName,
+        // productVariantName is `string | null` on the wire.
+        variantName: i.productVariantName ?? "",
         unitPrice: i.unitPrice,
         unitTaxExclusivePrice: i.unitTaxExclusivePrice ?? i.unitPrice,
         quantity: i.quantity,
       })),
-      discount:
-        (item as any).totalDiscountAmount ?? item.appliedDiscountAmount ?? 0,
-      discountId: (item as any).appliedDiscountId ?? null,
+      // Shared resolver — `totalDiscountAmount ?? manualDiscountAmount` used to
+      // drop the discount entirely, because the server sends 0 rather than null.
+      discount: resolveDiscount(item),
+      discountId: item.appliedDiscountId,
       notes: item.notes ?? "",
-      expiresAt: item.expiresAt ? String(item.expiresAt).split("T")[0] : "",
-      showTaxBreakdown: (item as any).showTaxAmounts ?? false,
+      expiresAt: item.expiresAt ? item.expiresAt.split("T")[0] : "",
+      showTaxBreakdown: item.showTaxAmounts ?? false,
       business: {
-        businessName: item.businessName ?? null,
-        locationName: item.locationName ?? null,
-        locationAddress: item.locationAddress ?? null,
-        locationPhoneNumber: item.locationPhoneNumber ?? null,
-        locationLogo: item.locationLogo ?? null,
+        businessName: item.businessName,
+        locationName: item.locationName,
+        locationAddress: item.locationAddress,
+        locationPhoneNumber: item.locationPhoneNumber,
+        locationLogo: item.locationLogo,
+        // Was missing on the edit path — the TIN silently vanished from the
+        // preview header when editing an existing proforma.
+        tinNumber: item.tinNumber ?? null,
       },
-      grossAmount: (item as any).grossAmount ?? 0,
-      taxExclusiveGrossAmount: (item as any).taxExclusiveGrossAmount ?? 0,
-      taxAmount: (item as any).taxAmount ?? 0,
-      netAmount: (item as any).netAmount ?? 0,
-      // ─── NEW ───────────────────────────────────────────────────────────
+      grossAmount: item.grossAmount ?? 0,
+      taxExclusiveGrossAmount: item.taxExclusiveGrossAmount ?? 0,
+      taxAmount: item.taxAmount ?? 0,
+      netAmount: item.netAmount ?? 0,
       isPreviewLoading: false,
     };
   });
@@ -2104,6 +2187,7 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
         ...prev,
         id: proformaId,
         proformaNumber,
+        proformaStatus: result.data.proformaStatus ?? null,
         customer,
         business,
       }));
@@ -2122,7 +2206,6 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
       if (!state.id) return;
       setError(null);
 
-      // Show loading overlay on the preview immediately
       setState((prev) => ({ ...prev, isPreviewLoading: true }));
 
       const result = await addItemsToProforma(state.id, {
@@ -2133,15 +2216,16 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
       if (result?.responseType === "error") {
         setError(result.message);
         toast.error(result.message);
-        // Always clear the loading flag — even on error
         setState((prev) => ({ ...prev, isPreviewLoading: false }));
         return;
       }
 
-      const data = result?.data as any;
-      const itemId: string = data?.id ?? newItem.variantId;
-      const unitTaxExclusivePrice: number =
-        data?.unitTaxExclusivePrice ?? newItem.unitTaxExclusivePrice;
+      const data = result?.data as Record<string, unknown> | undefined;
+      const itemId = typeof data?.id === "string" ? data.id : newItem.variantId;
+      const unitTaxExclusivePrice =
+        typeof data?.unitTaxExclusivePrice === "number"
+          ? data.unitTaxExclusivePrice
+          : newItem.unitTaxExclusivePrice;
 
       setState((prev) => ({
         ...prev,
@@ -2150,11 +2234,18 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
           ...prev.items,
           { ...newItem, itemId, quantity, unitTaxExclusivePrice },
         ],
-        grossAmount: data?.grossAmount ?? prev.grossAmount,
+        grossAmount:
+          typeof data?.grossAmount === "number"
+            ? data.grossAmount
+            : prev.grossAmount,
         taxExclusiveGrossAmount:
-          data?.taxExclusiveGrossAmount ?? prev.taxExclusiveGrossAmount,
-        taxAmount: data?.taxAmount ?? prev.taxAmount,
-        netAmount: data?.netAmount ?? prev.netAmount,
+          typeof data?.taxExclusiveGrossAmount === "number"
+            ? data.taxExclusiveGrossAmount
+            : prev.taxExclusiveGrossAmount,
+        taxAmount:
+          typeof data?.taxAmount === "number" ? data.taxAmount : prev.taxAmount,
+        netAmount:
+          typeof data?.netAmount === "number" ? data.netAmount : prev.netAmount,
       }));
 
       toast.success("Item added");
@@ -2171,7 +2262,6 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
       setRemovingIndex(index);
       if (editingIndex === index) setEditingIndex(null);
 
-      // Show loading overlay on the preview
       setState((prev) => ({ ...prev, isPreviewLoading: true }));
 
       const result = await removeItemsToProforma(state.id, lineItem.itemId);
@@ -2180,22 +2270,41 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
       if (result?.responseType === "error") {
         setError(result.message);
         toast.error(result.message);
-        // Clear loading flag on error
         setState((prev) => ({ ...prev, isPreviewLoading: false }));
         return;
       }
 
-      const data = result?.data as any;
-      setState((prev) => ({
-        ...prev,
-        isPreviewLoading: false,
-        items: prev.items.filter((_, i) => i !== index),
-        grossAmount: data?.grossAmount ?? prev.grossAmount,
-        taxExclusiveGrossAmount:
-          data?.taxExclusiveGrossAmount ?? prev.taxExclusiveGrossAmount,
-        taxAmount: data?.taxAmount ?? prev.taxAmount,
-        netAmount: data?.netAmount ?? prev.netAmount,
-      }));
+      const data = result?.data as Record<string, unknown> | undefined;
+
+      setState((prev) => {
+        // Filter by itemId, not index — the index could be stale by the time the
+        // request resolves if the list changed underneath us.
+        const items = prev.items.filter((it) => it.itemId !== lineItem.itemId);
+        return {
+          ...prev,
+          isPreviewLoading: false,
+          items,
+          grossAmount:
+            typeof data?.grossAmount === "number"
+              ? data.grossAmount
+              : items.reduce((s, it) => s + it.unitPrice * it.quantity, 0),
+          taxExclusiveGrossAmount:
+            typeof data?.taxExclusiveGrossAmount === "number"
+              ? data.taxExclusiveGrossAmount
+              : items.reduce(
+                  (s, it) => s + it.unitTaxExclusivePrice * it.quantity,
+                  0,
+                ),
+          taxAmount:
+            typeof data?.taxAmount === "number"
+              ? data.taxAmount
+              : prev.taxAmount,
+          netAmount:
+            typeof data?.netAmount === "number"
+              ? data.netAmount
+              : prev.netAmount,
+        };
+      });
 
       toast.success("Item removed");
     },
@@ -2208,7 +2317,6 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
       if (!state.id) return;
       setError(null);
 
-      // Show loading overlay on the preview
       setState((prev) => ({ ...prev, isPreviewLoading: true }));
 
       const result = await editItemPriceOrQuantityToProforma(
@@ -2226,10 +2334,9 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
       }
 
       // The edit-item endpoint returns the updated line item, NOT the parent
-      // proforma. Pull proforma-level totals from the response when present;
-      // otherwise recompute them from the updated items list so the preview
-      // always reflects the correct values without requiring a page reload.
-      const data = result?.data as any;
+      // proforma. Prefer proforma-level totals from the response when present;
+      // otherwise recompute from the updated items list.
+      const data = result?.data as Record<string, unknown> | undefined;
 
       setState((prev) => {
         const updatedItems = prev.items.map((it) =>
@@ -2238,14 +2345,14 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
                 ...it,
                 quantity,
                 unitPrice: unitCustomPrice,
-                // The item response does carry unitTaxExclusivePrice
                 unitTaxExclusivePrice:
-                  data?.unitTaxExclusivePrice ?? unitCustomPrice,
+                  typeof data?.unitTaxExclusivePrice === "number"
+                    ? data.unitTaxExclusivePrice
+                    : unitCustomPrice,
               }
             : it,
         );
 
-        // Prefer server-computed totals; fall back to client derivation.
         const grossAmount =
           typeof data?.grossAmount === "number"
             ? data.grossAmount
@@ -2265,7 +2372,7 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
         const taxAmount =
           typeof data?.taxAmount === "number"
             ? data.taxAmount
-            : grossAmount - taxExclusiveGrossAmount;
+            : Math.max(0, grossAmount - taxExclusiveGrossAmount);
 
         const netAmount =
           typeof data?.netAmount === "number"
@@ -2300,8 +2407,6 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
       if (!state.id) return;
       setError(null);
       setDetailsPending(true);
-
-      // Show loading overlay on the preview
       setState((prev) => ({ ...prev, isPreviewLoading: true }));
 
       const result = await updateProforma(
@@ -2317,17 +2422,23 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
 
       if (result?.responseType === "error") {
         setError(result.message);
-        // Clear loading flag on error
         setState((prev) => ({ ...prev, isPreviewLoading: false }));
         return;
       }
 
       const data = result?.data as Record<string, unknown> | undefined;
-      const appliedDiscount =
-        typeof data?.totalDiscountAmount === "number" &&
-        data.totalDiscountAmount > 0
-          ? data.totalDiscountAmount
-          : opts.manualDiscountAmount;
+
+      // The old version was:
+      //   totalDiscountAmount > 0 ? totalDiscountAmount : opts.manualDiscountAmount
+      // When the user picked an API discount, manualDiscountAmount is 0 — so a
+      // server response of totalDiscountAmount: 0 wiped the discount from state
+      // entirely. Fall through every field the server might have populated.
+      const appliedDiscount = firstPositive([
+        data?.totalDiscountAmount as number | undefined,
+        data?.appliedDiscountAmount as number | undefined,
+        data?.manualDiscountAmount as number | undefined,
+        opts.manualDiscountAmount,
+      ]);
 
       setState((prev) => ({
         ...prev,
@@ -2424,7 +2535,9 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
                   </div>
                   <div className="min-w-0 flex-1">
                     <p className="text-sm font-semibold text-gray-900 truncate">
-                      {state.customer.firstName} {state.customer.lastName}
+                      {[state.customer.firstName, state.customer.lastName]
+                        .filter(Boolean)
+                        .join(" ") || "—"}
                     </p>
                     <p className="text-xs text-gray-400 truncate">
                       {state.customer.phoneNumber}
@@ -2477,12 +2590,13 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
                           <div className="min-w-0">
                             <p className="text-sm font-medium text-gray-900 truncate">
                               {it.productName}
-                              {it.variantName && (
-                                <span className="text-gray-400 font-normal">
-                                  {" "}
-                                  — {it.variantName}
-                                </span>
-                              )}
+                              {it.variantName &&
+                                it.variantName !== it.productName && (
+                                  <span className="text-gray-400 font-normal">
+                                    {" "}
+                                    — {it.variantName}
+                                  </span>
+                                )}
                             </p>
                             <p className="text-xs text-gray-400">
                               {it.quantity} × {fmt(it.unitPrice)}
@@ -2583,6 +2697,7 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
               initialNote={state.notes}
               initialExpiresAt={state.expiresAt}
               initialDiscount={state.discount}
+              initialDiscountId={state.discountId}
               showTaxBreakdown={state.showTaxBreakdown}
               onTaxBreakdownChange={(v) =>
                 setState((prev) => ({ ...prev, showTaxBreakdown: v }))
@@ -2594,7 +2709,7 @@ export default function ProformaWizard({ item }: ProformaInvoiceFormProps) {
         </CardContent>
       </Card>
 
-      {/* ── Preview — pass isLoading so overlay activates during mutations ── */}
+      {/* ── Preview ── */}
       <div className="hidden lg:block">
         <ProformaPreview state={state} isLoading={state.isPreviewLoading} />
       </div>

--- a/components/proforma/proforma-details.tsx
+++ b/components/proforma/proforma-details.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import type { Proforma } from "@/types/proforma/type";
+import type {
+  Proforma,
+  ProformaItem,
+  ProformaStatus,
+} from "@/types/proforma/type";
 
 // ─── Brand tokens ─────────────────────────────────────────────────────────────
 const PRIMARY = "#EB7F44";
@@ -13,34 +17,72 @@ const fmt = (n: number) =>
     style: "currency",
     currency: "TZS",
     minimumFractionDigits: 2,
-  }).format(n);
+  }).format(Number.isFinite(n) ? n : 0);
 
 const fmtDate = (d: string | null | undefined) => {
   if (!d) return null;
-  try {
-    return new Date(d).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  } catch {
-    return d;
-  }
+  const parsed = new Date(d);
+  if (Number.isNaN(parsed.getTime())) return d;
+  return parsed.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
 };
 
 const fmtDateShort = (d: string | null | undefined) => {
   if (!d) return "";
-  try {
-    return new Date(d).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  } catch {
-    return d;
+  const parsed = new Date(d);
+  if (Number.isNaN(parsed.getTime())) return d;
+  return parsed.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+/** Money comparison that tolerates float noise. */
+const nearlyEqual = (a: number, b: number, epsilon = 0.01) =>
+  Math.abs(a - b) < epsilon;
+
+/**
+ * Resolve the discount.
+ *
+ * THE ORIGINAL BUG: `data.totalDiscountAmount ?? data.manualDiscountAmount`.
+ * `??` only falls through on null/undefined. The backend sends
+ * `totalDiscountAmount: 0` — a real number — so the 5,000 TZS manual discount
+ * was never read and the discount row never rendered.
+ */
+const resolveDiscount = (data: Proforma): number => {
+  const candidates = [
+    data.totalDiscountAmount,
+    data.manualDiscountAmount,
+    data.appliedDiscountAmount,
+  ];
+  for (const c of candidates) {
+    if (typeof c === "number" && c > 0) return c;
   }
+  return 0;
+};
+
+/** Derive the VAT rate from the payload rather than hardcoding 18%. */
+const deriveVatRate = (taxExclusiveGross: number, taxAmount: number) => {
+  if (taxExclusiveGross <= 0 || taxAmount <= 0) return null;
+  return Math.round((taxAmount / taxExclusiveGross) * 100);
+};
+
+const STATUS_STYLES: Record<
+  ProformaStatus,
+  { label: string; bg: string; fg: string }
+> = {
+  DRAFT: { label: "Draft", bg: "#f3f4f6", fg: "#374151" },
+  AWAITING: { label: "Awaiting confirmation", bg: "#fef3c7", fg: "#92400e" },
+  CONFIRMED: { label: "Confirmed by customer", bg: "#d1fae5", fg: "#065f46" },
+  COMPLETED: { label: "Completed", bg: "#d1fae5", fg: "#065f46" },
+  EXPIRED: { label: "Expired", bg: "#fee2e2", fg: "#991b1b" },
+  CANCELLED: { label: "Cancelled", bg: "#f3f4f6", fg: "#374151" },
 };
 
 // ─── Skeleton ─────────────────────────────────────────────────────────────────
@@ -114,21 +156,60 @@ export function DetailsSkeleton() {
 export function InvoiceDocument({
   data,
   printRef,
+  /**
+   * When the server's `netAmount` doesn't equal `gross - discount`, prefer the
+   * locally computed figure so the printed document at least adds up.
+   * Set to `false` once the backend is fixed and `netAmount` is authoritative.
+   */
+  reconcileTotals = true,
 }: {
   data: Proforma;
   printRef: React.RefObject<HTMLDivElement>;
+  reconcileTotals?: boolean;
 }) {
   const customerName =
     `${data.customerFirstName ?? ""} ${data.customerLastName ?? ""}`.trim();
 
-  const taxExclusiveGross: number = (data as any).taxExclusiveGrossAmount ?? 0;
-  const taxAmount: number = (data as any).taxAmount ?? 0;
-  const grossAmount: number = (data as any).grossAmount ?? 0;
-  const discountAmount: number = data.totalDiscountAmount ?? 0;
-  const netAmount: number = data.netAmount ?? 0;
+  const taxExclusiveGross = data.taxExclusiveGrossAmount ?? 0;
+  const taxAmount = data.taxAmount ?? 0;
+  const grossAmount = data.grossAmount ?? 0;
+  const serverNet = data.netAmount ?? 0;
 
-  // ✅ Use showTaxAmounts from payload — not derived from taxAmount > 0
-  const showTax: boolean = (data as any).showTaxAmounts === true;
+  const showTax = data.showTaxAmounts === true;
+  const vatRate = deriveVatRate(taxExclusiveGross, taxAmount);
+
+  // ── Discount + totals reconciliation ──
+  const discountAmount = resolveDiscount(data);
+  const computedNet = Math.max(0, grossAmount - discountAmount);
+  const totalsMismatch =
+    discountAmount > 0 && !nearlyEqual(serverNet, computedNet);
+  const netAmount = totalsMismatch && reconcileTotals ? computedNet : serverNet;
+
+  if (totalsMismatch && process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[Proforma ${data.proformaNumber}] totals do not reconcile: ` +
+        `gross ${grossAmount} - discount ${discountAmount} = ${computedNet}, ` +
+        `but the server returned netAmount ${serverNet}. The backend is likely ` +
+        `not applying manualDiscountAmount to netAmount, nor writing it back ` +
+        `into totalDiscountAmount.`,
+    );
+  }
+
+  /** VAT is the server figure, computed on the pre-discount gross. */
+  const discountAffectsVat = showTax && discountAmount > 0 && taxAmount > 0;
+
+  const lineExTotal = (it: ProformaItem) =>
+    it.lineTaxExclusiveTotal ?? it.unitTaxExclusivePrice * it.quantity;
+  const lineIncTotal = (it: ProformaItem) =>
+    it.lineTotal ?? it.unitPrice * it.quantity;
+
+  const unitPriceFor = (it: ProformaItem) =>
+    showTax ? it.unitTaxExclusivePrice : it.unitPrice;
+  const lineTotalFor = (it: ProformaItem) =>
+    showTax ? lineExTotal(it) : lineIncTotal(it);
+
+  const status = STATUS_STYLES[data.proformaStatus];
 
   return (
     <>
@@ -136,21 +217,42 @@ export function InvoiceDocument({
         @media print {
           body * { visibility: hidden !important; }
           #receipt-content, #receipt-content * { visibility: visible !important; }
+
+          /* Static flow so multi-page invoices paginate instead of being clipped
+             to one sheet by position:fixed + inset:0. */
           #receipt-content {
-            position: fixed !important;
-            inset: 0 !important;
-            padding: 32px !important;
+            position: static !important;
+            width: 100% !important;
+            max-width: none !important;
+            margin: 0 !important;
+            padding: 0 !important;
             background: white !important;
+            border: none !important;
             border-radius: 0 !important;
             box-shadow: none !important;
           }
+
+          /* Tailwind's lg: breakpoints resolve against the *paper* width when
+             printing, so a narrow window would otherwise print the mobile cards.
+             Force the table and hide the cards explicitly. */
+          #receipt-content .items-table { display: block !important; }
+          #receipt-content .items-cards { display: none !important; }
+
+          #receipt-content table { page-break-inside: auto; }
+          #receipt-content tr { page-break-inside: avoid; page-break-after: auto; }
+          #receipt-content thead { display: table-header-group; }
+          #receipt-content .totals-block,
+          #receipt-content .notes-block { page-break-inside: avoid; }
+
           .no-print { display: none !important; }
+
+          @page { margin: 16mm; }
         }
       `}</style>
 
       <div
         id="receipt-content"
-        ref={printRef as React.RefObject<HTMLDivElement>}
+        ref={printRef}
         className="bg-white rounded-lg shadow-sm mx-auto overflow-hidden"
         style={{ maxWidth: 794, border: `1px solid ${SECONDARY}` }}
       >
@@ -160,12 +262,13 @@ export function InvoiceDocument({
             {data.locationLogo ? (
               <img
                 src={data.locationLogo}
-                alt="Logo"
-                className="max-h-32 w-full object-contain flex-shrink-0"
+                alt={`${data.businessName ?? "Business"} logo`}
+                className="max-h-24 w-auto object-contain flex-shrink-0"
                 style={{ border: `1px solid ${SECONDARY}`, borderRadius: 4 }}
               />
             ) : (
-              <div className="h-20 w-20 rounded-lg flex items-center justify-center text-white text-xl font-bold flex-shrink-0" />
+              /* No logo: show the business name rather than an invisible box. */
+              <div></div>
             )}
           </div>
 
@@ -176,23 +279,33 @@ export function InvoiceDocument({
             >
               PROFORMA INVOICE
             </h2>
+
+            {status && (
+              <span
+                className="inline-block rounded-full px-3 py-1 text-xs font-semibold mb-2"
+                style={{ backgroundColor: status.bg, color: status.fg }}
+              >
+                {status.label}
+              </span>
+            )}
+
             <div className="text-sm text-gray-600 space-y-0.5">
               {data.tinNumber && (
                 <p className="font-semibold text-gray-800">
                   TIN: {data.tinNumber}
                 </p>
               )}
-              <p className="font-semibold text-gray-800">{data.businessName}</p>
-              {data.locationAddress && <p>{data.locationAddress}</p>}
-              {(data as any).locationCity && (
-                <p>{(data as any).locationCity}</p>
+              {data.businessName && (
+                <p className="font-semibold text-gray-800">
+                  {data.businessName}
+                </p>
               )}
+              {data.locationAddress && <p>{data.locationAddress}</p>}
+              {data.locationCity && <p>{data.locationCity}</p>}
               {data.locationPhoneNumber && (
                 <p>Mobile: {data.locationPhoneNumber}</p>
               )}
-              {(data as any).locationEmail && (
-                <p>{(data as any).locationEmail}</p>
-              )}
+              {data.locationEmail && <p>{data.locationEmail}</p>}
             </div>
           </div>
         </div>
@@ -213,17 +326,11 @@ export function InvoiceDocument({
               {customerName && (
                 <p className="font-semibold text-gray-900">{customerName}</p>
               )}
-              {(data as any).customerAddress && (
-                <p>{(data as any).customerAddress}</p>
-              )}
-              {(data as any).customerCity && (
-                <p>{(data as any).customerCity}</p>
-              )}
+              {data.customerAddress && <p>{data.customerAddress}</p>}
+              {data.customerCity && <p>{data.customerCity}</p>}
               {data.customerPhoneNumber && <p>{data.customerPhoneNumber}</p>}
               {data.customerEmail && <p>{data.customerEmail}</p>}
-              {(data as any).customerTin && (
-                <p>TIN: {(data as any).customerTin}</p>
-              )}
+              {data.customerTin && <p>TIN: {data.customerTin}</p>}
             </div>
           </div>
 
@@ -269,8 +376,8 @@ export function InvoiceDocument({
           </div>
         </div>
 
-        {/* ── ITEMS TABLE — desktop ── */}
-        <div className="hidden lg:block px-8 mb-6">
+        {/* ── ITEMS TABLE — desktop + print ── */}
+        <div className="items-table hidden lg:block px-8 mb-6">
           <table className="w-full text-sm">
             <thead>
               <tr style={{ backgroundColor: PRIMARY }}>
@@ -281,7 +388,6 @@ export function InvoiceDocument({
                   Quantity
                 </th>
                 <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-white">
-                  {/* ✅ Label changes based on showTax */}
                   {showTax ? "Unit Price (excl. VAT)" : "Price"}
                 </th>
                 <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-white">
@@ -302,30 +408,21 @@ export function InvoiceDocument({
                   <td className="px-4 py-3 text-gray-900">
                     <span className="text-gray-400 mr-2">{index + 1}.</span>
                     <span className="font-medium">{it.productName}</span>
-                    {it.productVariantName && (
-                      <span className="text-gray-400 text-xs ml-1">
-                        — {it.productVariantName}
-                      </span>
-                    )}
+                    {it.productVariantName &&
+                      it.productVariantName !== it.productName && (
+                        <span className="text-gray-400 text-xs ml-1">
+                          — {it.productVariantName}
+                        </span>
+                      )}
                   </td>
                   <td className="px-4 py-3 text-gray-600 text-center">
                     {it.quantity.toLocaleString()}
                   </td>
                   <td className="px-4 py-3 text-gray-600 text-right">
-                    {/* ✅ Show ex-tax price when showTax, otherwise VAT-inclusive */}
-                    {fmt(
-                      showTax
-                        ? (it as any).unitTaxExclusivePrice
-                        : it.unitPrice,
-                    )}
+                    {fmt(unitPriceFor(it))}
                   </td>
                   <td className="px-4 py-3 font-medium text-gray-900 text-right">
-                    {/* ✅ Line total follows the same rule */}
-                    {fmt(
-                      showTax
-                        ? (it as any).unitTaxExclusivePrice * it.quantity
-                        : it.unitPrice * it.quantity,
-                    )}
+                    {fmt(lineTotalFor(it))}
                   </td>
                 </tr>
               ))}
@@ -333,8 +430,8 @@ export function InvoiceDocument({
           </table>
         </div>
 
-        {/* ── ITEMS CARDS — mobile ── */}
-        <div className="lg:hidden px-4 mb-6 space-y-3">
+        {/* ── ITEMS CARDS — mobile screen only ── */}
+        <div className="items-cards lg:hidden px-4 mb-6 space-y-3">
           <div
             className="flex justify-between items-center px-4 py-2 rounded-t-lg text-white text-xs font-semibold uppercase tracking-wider"
             style={{ backgroundColor: PRIMARY }}
@@ -355,19 +452,15 @@ export function InvoiceDocument({
                 <p className="text-sm font-medium text-gray-900 flex-1">
                   <span className="text-gray-400 mr-1">{index + 1}.</span>
                   {it.productName}
-                  {it.productVariantName && (
-                    <span className="text-gray-400 text-xs ml-1">
-                      — {it.productVariantName}
-                    </span>
-                  )}
+                  {it.productVariantName &&
+                    it.productVariantName !== it.productName && (
+                      <span className="text-gray-400 text-xs ml-1">
+                        — {it.productVariantName}
+                      </span>
+                    )}
                 </p>
                 <p className="text-sm font-bold whitespace-nowrap">
-                  {/* ✅ Mobile card amount also respects showTax */}
-                  {fmt(
-                    showTax
-                      ? (it as any).unitTaxExclusivePrice * it.quantity
-                      : it.unitPrice * it.quantity,
-                  )}
+                  {fmt(lineTotalFor(it))}
                 </p>
               </div>
               <div className="flex flex-wrap gap-4 text-xs text-gray-500">
@@ -379,9 +472,7 @@ export function InvoiceDocument({
                   <span className="font-medium text-gray-700">
                     {showTax ? "Unit price (excl. VAT):" : "Unit price:"}
                   </span>{" "}
-                  {fmt(
-                    showTax ? (it as any).unitTaxExclusivePrice : it.unitPrice,
-                  )}
+                  {fmt(unitPriceFor(it))}
                 </span>
               </div>
             </div>
@@ -389,12 +480,11 @@ export function InvoiceDocument({
         </div>
 
         {/* ── TOTALS ── */}
-        <div className="px-6 lg:px-8 mb-6">
+        <div className="totals-block px-6 lg:px-8 mb-6">
           <div className="flex justify-end">
             <div className="w-full lg:max-w-xs">
               {showTax ? (
                 <>
-                  {/* Subtotal before VAT */}
                   <div
                     className="flex justify-between text-sm text-gray-600 py-2"
                     style={{ borderBottom: `1px solid ${SECONDARY}` }}
@@ -403,7 +493,6 @@ export function InvoiceDocument({
                     <span>{fmt(taxExclusiveGross)}</span>
                   </div>
 
-                  {/* VAT */}
                   <div
                     className="flex justify-between text-sm py-2"
                     style={{
@@ -411,11 +500,12 @@ export function InvoiceDocument({
                       color: "#059669",
                     }}
                   >
-                    <span className="font-medium">VAT (18%):</span>
+                    <span className="font-medium">
+                      VAT{vatRate !== null ? ` (${vatRate}%)` : ""}:
+                    </span>
                     <span className="font-medium">+ {fmt(taxAmount)}</span>
                   </div>
 
-                  {/* Gross incl. VAT */}
                   <div
                     className="flex justify-between text-sm text-gray-600 py-2"
                     style={{ borderBottom: `1px solid ${SECONDARY}` }}
@@ -425,7 +515,6 @@ export function InvoiceDocument({
                   </div>
                 </>
               ) : (
-                /* ✅ showTax false — simple subtotal, no VAT lines */
                 <div
                   className="flex justify-between text-sm text-gray-600 py-2"
                   style={{ borderBottom: `1px solid ${SECONDARY}` }}
@@ -435,7 +524,6 @@ export function InvoiceDocument({
                 </div>
               )}
 
-              {/* Discount */}
               {discountAmount > 0 && (
                 <div
                   className="flex justify-between text-sm py-2"
@@ -449,7 +537,6 @@ export function InvoiceDocument({
                 </div>
               )}
 
-              {/* Grand Total */}
               <div
                 className="flex justify-between font-bold py-3 mt-1 rounded px-3"
                 style={{ backgroundColor: PRIMARY_LIGHT, color: PRIMARY }}
@@ -458,10 +545,16 @@ export function InvoiceDocument({
                 <span>{fmt(netAmount)}</span>
               </div>
 
-              {/* ✅ VAT note — only when showTax is true */}
-              {showTax && taxAmount > 0 && (
+              {showTax && taxAmount > 0 && !discountAffectsVat && (
                 <p className="text-[11px] text-gray-400 mt-2 text-right">
                   VAT of {fmt(taxAmount)} is included in the grand total
+                </p>
+              )}
+
+              {discountAffectsVat && (
+                <p className="text-[11px] text-gray-400 mt-2 text-right">
+                  VAT of {fmt(taxAmount)} is calculated on the gross amount
+                  before discount
                 </p>
               )}
             </div>
@@ -470,7 +563,7 @@ export function InvoiceDocument({
 
         {/* ── NOTES / TERMS ── */}
         {data.notes && (
-          <>
+          <div className="notes-block">
             <div
               className="mx-8"
               style={{ height: 1, backgroundColor: SECONDARY }}
@@ -480,12 +573,12 @@ export function InvoiceDocument({
                 Notes / Terms
               </p>
               <div className="text-sm text-gray-600 space-y-1 leading-relaxed">
-                {data.notes.split("\n").map((line: string, i: number) => (
+                {data.notes.split("\n").map((line, i) => (
                   <p key={i}>{line}</p>
                 ))}
               </div>
             </div>
-          </>
+          </div>
         )}
 
         {/* ── Footer ── */}
@@ -512,7 +605,7 @@ export function InvoiceDocument({
               Thank you for your business and continued support
             </p>
             <p className="text-xs text-gray-400 mt-0.5">
-              Powered by Settlo Technologies
+              Powered by Settlo Technologies Limited
             </p>
           </div>
         </div>

--- a/components/tables/proforma-invoice/cell-action.tsx
+++ b/components/tables/proforma-invoice/cell-action.tsx
@@ -2,10 +2,9 @@
 
 import { useRouter } from "next/navigation";
 import React from "react";
-
 import { Pencil as EditIcon, Eye as EyeIcon } from "lucide-react";
-
-import { Proforma } from "@/types/proforma/type";
+import { isProformaEditable } from "@/types/proforma/type";
+import type { Proforma } from "@/types/proforma/type";
 
 interface CellActionProps {
   data: Proforma;
@@ -13,39 +12,29 @@ interface CellActionProps {
 
 export const CellAction: React.FC<CellActionProps> = ({ data }) => {
   const router = useRouter();
+  const canEdit = isProformaEditable(data.proformaStatus);
 
   return (
-    <>
-      <div style={{ alignItems: "flex-end" }}>
-        <div
-          style={{
-            display: "flex",
-            float: "right",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 16,
-            fontSize: 20,
-          }}
+    <div className="flex items-center justify-end gap-4">
+      <button
+        type="button"
+        onClick={() => router.push(`/proforma-invoice/details/${data.id}`)}
+        className="cursor-pointer"
+        title="View proforma"
+      >
+        <EyeIcon color="#384B70" size={20} />
+      </button>
+
+      {canEdit && (
+        <button
+          type="button"
+          onClick={() => router.push(`/proforma-invoice/${data.id}`)}
+          className="cursor-pointer"
+          title="Edit proforma"
         >
-          <a
-            style={{ flex: 1 }}
-            onClick={() => router.push(`/proforma-invoice/details/${data.id}`)}
-            className="cursor-pointer"
-          >
-            <EyeIcon color={"#384B70"} />
-          </a>
-          {data.proformaStatus !== "COMPLETE" &&
-            data.proformaStatus !== "ACCEPTED" && (
-              <a
-                style={{ flex: 1 }}
-                onClick={() => router.push(`/proforma-invoice/${data.id}`)}
-                className="cursor-pointer"
-              >
-                <EditIcon color={"#384B70"} />
-              </a>
-            )}
-        </div>
-      </div>
-    </>
+          <EditIcon color="#384B70" size={20} />
+        </button>
+      )}
+    </div>
   );
 };

--- a/components/tables/proforma-invoice/column.tsx
+++ b/components/tables/proforma-invoice/column.tsx
@@ -1,57 +1,101 @@
 "use client";
+
 import { ColumnDef } from "@tanstack/react-table";
-import { ArrowUpDown, CheckCircle2, Clock, ThumbsUp } from "lucide-react";
+import {
+  ArrowUpDown,
+  CheckCircle2,
+  Clock,
+  ThumbsUp,
+  XCircle,
+  FileEdit,
+} from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { CellAction } from "@/components/tables/proforma-invoice/cell-action";
-import { Proforma } from "@/types/proforma/type";
+import type { Proforma, ProformaStatus } from "@/types/proforma/type";
+import { resolveDiscount, resolveTotals } from "@/lib/actions/total";
+
+// ─── Formatters ───────────────────────────────────────────────────────────────
 
 const formatCurrency = (value: number) =>
   new Intl.NumberFormat("en", {
     style: "currency",
     currency: "TZS",
     minimumFractionDigits: 2,
-  }).format(value);
+  }).format(Number.isFinite(value) ? value : 0);
 
-const formatDate = (value?: Date | string) => {
+/**
+ * `expiresAt` is `string | null` on the wire, hence the null in the signature.
+ *
+ * Note there's no try/catch: `new Date("garbage")` returns an Invalid Date
+ * rather than throwing, so the old catch block never actually fired. Checking
+ * `getTime()` for NaN is what catches a bad value.
+ */
+const formatDate = (value?: Date | string | null) => {
   if (!value) return "—";
-  try {
-    return new Date(value).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  } catch {
-    return String(value);
-  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return String(value);
+  return parsed.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 };
+
+const fullName = (p: Proforma) =>
+  [p.customerFirstName, p.customerLastName].filter(Boolean).join(" ");
 
 // ─── Status Badge ─────────────────────────────────────────────────────────────
 
-function ProformaStatusBadge({ status }: { status: string }) {
-  const map: Record<
-    string,
-    { label: string; icon: React.ReactNode; className: string }
-  > = {
-    DRAFT: {
-      label: "Draft",
-      icon: <Clock className="w-3 h-3" />,
-      className: "bg-amber-50 text-amber-700 border-amber-200",
-    },
-    COMPLETE: {
-      label: "Complete",
-      icon: <CheckCircle2 className="w-3 h-3" />,
-      className: "bg-green-50 text-green-700 border-green-200",
-    },
-    ACCEPTED: {
-      label: "Accepted",
-      icon: <ThumbsUp className="w-3 h-3" />,
-      className: "bg-blue-50 text-blue-700 border-blue-200",
-    },
-  };
+/**
+ * Typed as `Record<ProformaStatus, …>` deliberately: adding a status to the
+ * union without adding a badge here is now a build failure, rather than a grey
+ * pill showing the raw enum string in production.
+ *
+ * The old map keyed on "COMPLETE" and "ACCEPTED" — neither of which the API
+ * sends — and had no entry for "AWAITING", which it does send.
+ */
+const STATUS_CONFIG: Record<
+  ProformaStatus,
+  { label: string; icon: React.ReactNode; className: string }
+> = {
+  DRAFT: {
+    label: "Draft",
+    icon: <FileEdit className="w-3 h-3" />,
+    className: "bg-gray-50 text-gray-600 border-gray-200",
+  },
+  AWAITING: {
+    label: "Awaiting",
+    icon: <Clock className="w-3 h-3" />,
+    className: "bg-amber-50 text-amber-700 border-amber-200",
+  },
+  CONFIRMED: {
+    label: "Confirmed",
+    icon: <ThumbsUp className="w-3 h-3" />,
+    className: "bg-blue-50 text-blue-700 border-blue-200",
+  },
+  COMPLETED: {
+    label: "Completed",
+    icon: <CheckCircle2 className="w-3 h-3" />,
+    className: "bg-green-50 text-green-700 border-green-200",
+  },
+  EXPIRED: {
+    label: "Expired",
+    icon: <XCircle className="w-3 h-3" />,
+    className: "bg-red-50 text-red-700 border-red-200",
+  },
+  CANCELLED: {
+    label: "Cancelled",
+    icon: <XCircle className="w-3 h-3" />,
+    className: "bg-gray-50 text-gray-500 border-gray-200",
+  },
+};
 
-  const cfg = map[status] ?? {
-    label: status,
+function ProformaStatusBadge({ status }: { status: ProformaStatus }) {
+  const cfg = STATUS_CONFIG[status] ?? {
+    // Defensive only — if this branch renders, the API sent a status that isn't
+    // in the union and the type needs updating.
+    label: String(status),
     icon: null,
     className: "bg-gray-50 text-gray-600 border-gray-200",
   };
@@ -63,6 +107,28 @@ function ProformaStatusBadge({ status }: { status: string }) {
       {cfg.icon}
       {cfg.label}
     </span>
+  );
+}
+
+// ─── Sortable header ──────────────────────────────────────────────────────────
+
+function SortableHeader({
+  column,
+  label,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  column: any;
+  label: string;
+}) {
+  return (
+    <Button
+      className="text-left p-0"
+      variant="ghost"
+      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+    >
+      {label}
+      <ArrowUpDown className="ml-2 h-4 w-4" />
+    </Button>
   );
 }
 
@@ -88,18 +154,12 @@ export const columns: ColumnDef<Proforma>[] = [
     enableSorting: false,
     enableHiding: false,
   },
+
   {
     accessorKey: "proformaNumber",
     enableHiding: false,
     header: ({ column }) => (
-      <Button
-        className="text-left p-0"
-        variant="ghost"
-        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-      >
-        Invoice #
-        <ArrowUpDown className="ml-2 h-4 w-4" />
-      </Button>
+      <SortableHeader column={column} label="Invoice #" />
     ),
     cell: ({ row }) => (
       <span className="font-medium text-blue-600 whitespace-nowrap">
@@ -107,53 +167,46 @@ export const columns: ColumnDef<Proforma>[] = [
       </span>
     ),
   },
+
   {
     id: "customer",
-    header: ({ column }) => (
-      <Button
-        className="text-left p-0"
-        variant="ghost"
-        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-      >
-        Customer
-        <ArrowUpDown className="ml-2 h-4 w-4" />
-      </Button>
-    ),
+    // Was missing — the header had a sort button that toggled a sort with no
+    // underlying value, so clicking it did nothing.
+    accessorFn: (row) => fullName(row),
+    header: ({ column }) => <SortableHeader column={column} label="Customer" />,
     cell: ({ row }) => (
       <p className="font-medium text-sm whitespace-nowrap">
-        {row.original.customerFirstName} {row.original.customerLastName}
+        {fullName(row.original) || "—"}
       </p>
     ),
   },
+
   {
     accessorKey: "dateCreated",
-    header: "Creation Date",
+    header: ({ column }) => (
+      <SortableHeader column={column} label="Creation Date" />
+    ),
     cell: ({ row }) => (
       <span className="text-sm text-gray-600 whitespace-nowrap">
         {formatDate(row.original.dateCreated)}
       </span>
     ),
   },
+
   {
     accessorKey: "expiresAt",
-    header: "Due Date",
+    header: ({ column }) => <SortableHeader column={column} label="Due Date" />,
     cell: ({ row }) => (
       <span className="text-sm text-gray-600 whitespace-nowrap">
         {formatDate(row.original.expiresAt)}
       </span>
     ),
   },
+
   {
     accessorKey: "grossAmount",
     header: ({ column }) => (
-      <Button
-        className="text-left p-0"
-        variant="ghost"
-        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-      >
-        Gross Amount
-        <ArrowUpDown className="ml-2 h-4 w-4" />
-      </Button>
+      <SortableHeader column={column} label="Gross Amount" />
     ),
     cell: ({ row }) => (
       <span className="font-medium text-sm whitespace-nowrap">
@@ -161,31 +214,46 @@ export const columns: ColumnDef<Proforma>[] = [
       </span>
     ),
   },
+
   {
-    accessorKey: "totalDiscountAmount",
-    header: "Discount",
-    cell: ({ row }) => (
-      <span className="text-sm text-red-500 whitespace-nowrap">
-        {row.original.totalDiscountAmount > 0
-          ? `− ${formatCurrency(row.original.totalDiscountAmount)}`
-          : "—"}
-      </span>
-    ),
-  },
-  {
-    id: "netAmount",
-    header: "Net Amount",
+    id: "discount",
+    /**
+     * No `accessorKey: "totalDiscountAmount"` here on purpose. That field is 0
+     * on the wire even when a manual discount exists, so sorting by it would
+     * order rows by a value the cell isn't displaying. Sort by the resolved
+     * figure instead.
+     */
+    accessorFn: (row) => resolveDiscount(row),
+    header: ({ column }) => <SortableHeader column={column} label="Discount" />,
     cell: ({ row }) => {
-      const net =
-        (row.original.grossAmount ?? 0) -
-        (row.original.appliedDiscountAmount ?? 0);
+      const discount = resolveDiscount(row.original);
       return (
-        <span className="font-semibold text-sm whitespace-nowrap">
-          {formatCurrency(Math.max(0, net))}
+        <span className="text-sm text-red-500 whitespace-nowrap">
+          {discount > 0 ? `− ${formatCurrency(discount)}` : "—"}
         </span>
       );
     },
   },
+
+  {
+    id: "netAmount",
+    /**
+     * The old version computed `grossAmount - appliedDiscountAmount`, but
+     * `appliedDiscountAmount` is null for a manual discount — so the net came
+     * out equal to the gross and this table disagreed with the printed invoice.
+     * `resolveTotals` is the same helper InvoiceDocument uses.
+     */
+    accessorFn: (row) => resolveTotals(row).netAmount,
+    header: ({ column }) => (
+      <SortableHeader column={column} label="Net Amount" />
+    ),
+    cell: ({ row }) => (
+      <span className="font-semibold text-sm whitespace-nowrap">
+        {formatCurrency(resolveTotals(row.original).netAmount)}
+      </span>
+    ),
+  },
+
   {
     id: "status",
     accessorKey: "proformaStatus",
@@ -195,6 +263,7 @@ export const columns: ColumnDef<Proforma>[] = [
       <ProformaStatusBadge status={row.original.proformaStatus} />
     ),
   },
+
   {
     id: "actions",
     cell: ({ row }) => <CellAction data={row.original} />,

--- a/lib/actions/proforma-actions.tsx
+++ b/lib/actions/proforma-actions.tsx
@@ -70,7 +70,7 @@ export const getProforma = async (id: UUID): Promise<Proforma | null> => {
     const response = await apiClient.get(
       `/api/location/${location?.id}/order-proforma/${id}`,
     );
-    console.log("The proforma response", response);
+
     return parseStringify(response) as Proforma;
   } catch (error) {
     console.error(`[getProforma] Error fetching proforma ${id}:`, error);
@@ -111,6 +111,7 @@ export const createProforma = async (
   const payload = {
     ...validData.data,
   };
+
   try {
     const apiClient = new ApiClient();
 
@@ -175,7 +176,6 @@ export const addItemsToProforma = async (
       message: "Proforma items added successfully",
       data: response,
     };
-    console.log("The response after adding items", response);
   } catch (error) {
     formResponse = {
       responseType: "error",
@@ -253,6 +253,8 @@ export const updateProforma = async (
     showTaxAmounts,
   });
 
+  console.log("The proforma response", validData);
+
   if (!validData.success) {
     formResponse = {
       responseType: "error",
@@ -279,7 +281,6 @@ export const updateProforma = async (
     payload.manualDiscountAmount = validData.data.manualDiscountAmount;
   }
 
-  console.log("The payload updating ", payload);
   const location = await getCurrentLocation();
 
   try {

--- a/lib/actions/total.tsx
+++ b/lib/actions/total.tsx
@@ -1,0 +1,113 @@
+/**
+ * @/lib/proforma/totals
+ *
+ * Single source of truth for proforma money logic. Both the wizard
+ * (ProformaWizard) and the printable document (InvoiceDocument) import from
+ * here so the two can't drift apart.
+ */
+
+import type { Proforma } from "@/types/proforma/type";
+
+/** Return the first value in the list that is a number greater than zero. */
+export function firstPositive(
+  values: Array<number | null | undefined>,
+): number {
+  for (const v of values) {
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+  }
+  return 0;
+}
+
+/**
+ * Resolve the discount actually applied to a proforma.
+ *
+ * THE BUG THIS REPLACES: `totalDiscountAmount ?? manualDiscountAmount`.
+ * `??` only falls through on null/undefined, and the backend sends
+ * `totalDiscountAmount: 0` — a real number — so a manual discount was silently
+ * dropped everywhere this pattern appeared.
+ */
+export function resolveDiscount(
+  p: Pick<
+    Proforma,
+    "totalDiscountAmount" | "manualDiscountAmount" | "appliedDiscountAmount"
+  >,
+): number {
+  return firstPositive([
+    p.totalDiscountAmount,
+    p.manualDiscountAmount,
+    p.appliedDiscountAmount,
+  ]);
+}
+
+/** Money comparison that tolerates float noise. */
+export function nearlyEqual(a: number, b: number, epsilon = 0.01): boolean {
+  return Math.abs(a - b) < epsilon;
+}
+
+/** Derive the VAT rate from the payload rather than hardcoding 18%. */
+export function deriveVatRate(
+  taxExclusiveGross: number,
+  taxAmount: number,
+): number | null {
+  if (taxExclusiveGross <= 0 || taxAmount <= 0) return null;
+  return Math.round((taxAmount / taxExclusiveGross) * 100);
+}
+
+export interface ResolvedTotals {
+  taxExclusiveGross: number;
+  taxAmount: number;
+  grossAmount: number;
+  discountAmount: number;
+  /** What the server said. */
+  serverNet: number;
+  /** gross - discount. */
+  computedNet: number;
+  /** True when the server's net doesn't reconcile with gross - discount. */
+  mismatch: boolean;
+  /** The figure to actually display. */
+  netAmount: number;
+  vatRate: number | null;
+}
+
+/**
+ * Resolve every money figure for display.
+ *
+ * `preferComputed` decides what to show when the server's `netAmount` doesn't
+ * equal `gross - discount`. Leave it `true` until the backend correctly applies
+ * `manualDiscountAmount` to `netAmount`; then flip it to `false` so the server
+ * is authoritative.
+ */
+export function resolveTotals(
+  p: Pick<
+    Proforma,
+    | "taxExclusiveGrossAmount"
+    | "taxAmount"
+    | "grossAmount"
+    | "netAmount"
+    | "totalDiscountAmount"
+    | "manualDiscountAmount"
+    | "appliedDiscountAmount"
+  >,
+  preferComputed = true,
+): ResolvedTotals {
+  const taxExclusiveGross = p.taxExclusiveGrossAmount ?? 0;
+  const taxAmount = p.taxAmount ?? 0;
+  const grossAmount = p.grossAmount ?? 0;
+  const serverNet = p.netAmount ?? 0;
+
+  const discountAmount = resolveDiscount(p);
+  const computedNet = Math.max(0, grossAmount - discountAmount);
+  const mismatch = discountAmount > 0 && !nearlyEqual(serverNet, computedNet);
+
+  return {
+    taxExclusiveGross,
+    taxAmount,
+    grossAmount,
+    discountAmount,
+    serverNet,
+    computedNet,
+    mismatch,
+    netAmount: mismatch && preferComputed ? computedNet : serverNet,
+    vatRate: deriveVatRate(taxExclusiveGross, taxAmount),
+  };
+}

--- a/types/proforma/type.ts
+++ b/types/proforma/type.ts
@@ -1,30 +1,79 @@
-import { UUID } from "node:crypto";
+/**
+ * @/types/proforma/type
+ *
+ * Notes on changes:
+ * - Dropped `import { UUID } from "node:crypto"`. It's a Node builtin and this
+ *   type is consumed by client components. A UUID off the wire is a string.
+ * - `proformaStatus` is now a real union. The old one was
+ *   `"DRAFT" | "COMPLETED" | "CANCELLED" | string`, and the trailing `| string`
+ *   collapses the whole union to `string` — no autocomplete, no exhaustiveness
+ *   checking, and it silently permitted the `"CONFIRMED"` comparison in the
+ *   invoice component even though the server sends `"AWAITING"`.
+ * - Nullability now matches the payload: the discount amounts and customerTin
+ *   come back as `null`, not `0` / `""`.
+ */
+
+export type ProformaStatus =
+  | "DRAFT"
+  | "AWAITING"
+  | "CONFIRMED"
+  | "COMPLETED"
+  | "EXPIRED"
+  | "CANCELLED";
+
+export interface ProformaItem {
+  id: string;
+  productName: string;
+  productVariantName: string | null;
+  quantity: number;
+  /** VAT-inclusive unit price. */
+  unitPrice: number;
+  /** VAT-exclusive unit price. */
+  unitTaxExclusivePrice: number;
+  /**
+   * Optional server-computed line totals. Prefer these over multiplying
+   * unit price by quantity — for a fiscal document you want the server's
+   * rounding, not the client's float arithmetic.
+   */
+  lineTotal?: number | null;
+  lineTaxExclusiveTotal?: number | null;
+}
 
 export interface Proforma {
   id: string;
   proformaNumber: string;
-  proformaStatus: "DRAFT" | "COMPLETED" | "CANCELLED" | string;
+  proformaStatus: ProformaStatus;
   notes: string | null;
-  taxExclusiveGrossAmount: number;
+
+  // ── Money ──
   showTaxAmounts: boolean;
+  taxExclusiveGrossAmount: number;
   taxAmount: number;
   grossAmount: number;
-  manualDiscountAmount: number;
-  appliedDiscountAmount: number;
-  totalDiscountAmount: number;
-  appliedDiscountId: string | null;
   netAmount: number;
-  expiresAt: string;
+
+  manualDiscountAmount: number | null;
+  appliedDiscountAmount: number | null;
+  totalDiscountAmount: number | null;
+  appliedDiscountId: string | null;
+
+  // ── Dates ──
+  expiresAt: string | null;
   dateCreated: string;
-  customer: UUID;
-  customerFirstName: string;
-  customerLastName: string;
-  customerEmail: string;
-  customerPhoneNumber: string;
-  customerCity: string;
-  customerAddress: string;
-  customerTin: string;
+
+  // ── Customer ──
+  customer: string;
+  customerFirstName: string | null;
+  customerLastName: string | null;
+  customerEmail: string | null;
+  customerPhoneNumber: string | null;
+  customerCity: string | null;
+  customerAddress: string | null;
+  customerTin: string | null;
+
+  // ── Issuing business / location ──
   businessName: string | null;
+  locationId?: string;
   locationName: string | null;
   locationLogo: string | null;
   locationAddress: string | null;
@@ -32,14 +81,18 @@ export interface Proforma {
   locationEmail: string | null;
   locationPhoneNumber: string | null;
   tinNumber?: string | null;
+
   items: ProformaItem[];
 }
 
-export interface ProformaItem {
-  id: UUID;
-  unitPrice: number;
-  quantity: number;
-  productName: string;
-  productVariantName: string;
-  unitTaxExclusivePrice: number;
+export const LOCKED_PROFORMA_STATUSES = [
+  "CONFIRMED",
+  "COMPLETED",
+  "CANCELLED",
+] as const satisfies readonly ProformaStatus[];
+
+export function isProformaEditable(status: ProformaStatus): boolean {
+  return !LOCKED_PROFORMA_STATUSES.includes(
+    status as (typeof LOCKED_PROFORMA_STATUSES)[number],
+  );
 }


### PR DESCRIPTION
The Proforma type had `| string` on its status union and marked several nullable API fields as non-null, which hid two real bugs.

Discount: `totalDiscountAmount ?? manualDiscountAmount` only falls through on null, but the API sends 0 — so manual discounts were dropped from the invoice, the table, and the edit form. Added lib/proforma/totals.ts with resolveDiscount/resolveTotals and used it everywhere.

Status: the cell action gated editing on "COMPLETE"/"ACCEPTED" and the badge map keyed on the same, but the API sends "AWAITING". Every comparison compiled and always passed, so the edit icon showed on every row. Statuses are now a real union with an exhaustive badge map.

Also: null-safe date formatting, derived VAT rate instead of a hardcoded 18%, working customer sort, print CSS that doesn't clip multi-page invoices.

Backend still returns netAmount == grossAmount when a manual discount is present; the client reconciles and warns for now.